### PR TITLE
Add simplecov and codeclimate formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+coverage/

--- a/overloaded_methods.gemspec
+++ b/overloaded_methods.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rspec", "~> 3.0"
+  s.add_development_dependency "codeclimate-test-reporter", "~> 0.4.5"
+  s.add_development_dependency "simplecov", "~> 0.9.1"
 
   s.post_install_message = <<'Omg, frogs <3'.gsub(/(gg+)/) { |capture| "\e[32m#{capture.gsub 'g', '.'}\e[0m" }.gsub("brown", "\e[33m").gsub("off", "\e[0m")
               .7

--- a/spec/overloaded_methods_spec.rb
+++ b/spec/overloaded_methods_spec.rb
@@ -1,3 +1,14 @@
+require 'codeclimate-test-reporter'
+require 'simplecov'
+
+formatters = [SimpleCov::Formatter::HTMLFormatter]
+
+formatters << CodeClimate::TestReporter::Formatter if ENV['CODECLIMATE_REPO_TOKEN']
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[*formatters]
+
+SimpleCov.start
+
 require 'overloaded_methods'
 
 RSpec.configure do |c|


### PR DESCRIPTION
This adds simplecov and the codeclimate formatter.

It defaults to the HTML formatter, but when the CODECLIMATE_REPO_TOKEN environment variable is present, it will publish the coverage to codeclimate.

The environment variable can be found in the Test Coverage tab of the Codeclimate settings and must be configured on travis (see http://docs.codeclimate.com/article/219-setting-up-test-coverage)
